### PR TITLE
chore: tweaking globals.css code where all elements become zero padding and margin

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,8 +16,8 @@ body {
 
 * {
   box-sizing: border-box;
-  padding: 0;
-  margin: 0;
+  /* padding: 0;
+  margin: 0; */
 }
 
 a {
@@ -142,6 +142,7 @@ a {
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
This * padding:0 and margin:0 makes the tailwindcss behave strangely. It is commented for now.